### PR TITLE
include stdint.h

### DIFF
--- a/PackedDataFormatInfo.h
+++ b/PackedDataFormatInfo.h
@@ -23,6 +23,7 @@
  */
 #pragma once
 
+#include <stdint.h>
 #include <functional>
 #include <vector>
 


### PR DESCRIPTION
Otherwise, on Debian Stable/11, we get errors like:
`/home/dreamer/Sources/_audio/KnobKraft-orm/juce-utils/PackedDataFormatInfo.h:37:97: error: ‘uint8_t’ was not declared in this scope; did you mean ‘u_int8_t’?`